### PR TITLE
Proposed fix for Jenkins issue #5552

### DIFF
--- a/src/main/java/hudson/plugins/msbuild/MsBuildBuilder.java
+++ b/src/main/java/hudson/plugins/msbuild/MsBuildBuilder.java
@@ -9,6 +9,7 @@ import hudson.util.ArgumentListBuilder;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
+import java.net.URLEncoder;
 import java.util.Map;
 
 /**
@@ -128,7 +129,8 @@ public class MsBuildBuilder extends Builder {
             StringBuffer parameters = new StringBuffer();
             parameters.append("/p:");
             for (Map.Entry<String, String> entry : variables.entrySet()) {
-                parameters.append(entry.getKey()).append("=").append(entry.getValue()).append(";");
+                String value = URLEncoder.encode(entry.getValue(), "UTF-8");
+                parameters.append(entry.getKey()).append("=").append(value).append(";");
             }
             parameters.delete(parameters.length() - 1, parameters.length());
             args.add(parameters.toString());


### PR DESCRIPTION
This patch simply calls URLEncoder.encode on all parameter values before they
are passed to MSBuild. This ensures that characters like ',', '"' and ' ' are
escaped into %2C, %22 and + respectively.

Since MSBuild expect special characters to be urlencoded, this will prevent
errors for some users. For instance, when people also use Gerrit, the subject
line from the commit message is sent to MSBuild, and when that line contains
commas or parentheses - it will fail without this patch.
