### PR TITLE
[FIXED JENKINS-19830] Warn about passwords in log

### DIFF
--- a/src/main/resources/hudson/plugins/msbuild/MsBuildBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/msbuild/MsBuildBuilder/config.jelly
@@ -13,11 +13,11 @@
     <f:entry title="Command Line Arguments" help="${rootURL}/../plugin/msbuild/help-cmdLineArgs.html">
         <f:textbox name="msBuildBuilder.cmdLineArgs" value="${instance.cmdLineArgs}" />
     </f:entry>
+    <f:entry title="Pass build variables as properties" help="${rootURL}/../plugin/msbuild/help-buildVariablesAsProperties.html">
+        <f:checkbox name="msBuildBuilder.buildVariablesAsProperties" value="${instance.buildVariablesAsProperties}"
+                        checked="${instance.buildVariablesAsProperties}" default="false" />
+    </f:entry>
     <f:advanced>
-        <f:entry title="Pass build variables as properties" help="${rootURL}/../plugin/msbuild/help-buildVariablesAsProperties.html">
-            <f:checkbox name="msBuildBuilder.buildVariablesAsProperties" value="${instance.buildVariablesAsProperties}"
-                checked="${instance.buildVariablesAsProperties}" default="true" />
-        </f:entry>
         <f:entry title="Continue Job on build Failure" help="${rootURL}/../plugin/msbuild/help-continueOnBuildFailure.html">
             <f:checkbox name="msBuildBuilder.continueOnBuildFailure" value="${instance.continueOnBuildFailure}"
                 checked="${instance.continueOnBuildFailure}" default="false" />

--- a/src/main/webapp/help-BuildVariablesAsProperties.html
+++ b/src/main/webapp/help-BuildVariablesAsProperties.html
@@ -1,5 +1,8 @@
 <div>
     <p>
-        If set to true (the default), Jenkins build variables will be passed to MSBuild as /p:name=value pairs.
+        If set to true, Jenkins build variables will be passed to MSBuild as /p:name=value pairs.
+    </p>
+    <p>
+        <strong>Beware</strong> that enabling this feature may cause sensitive information such as passwords to appear in the console log.
     </p>
 </div>


### PR DESCRIPTION
[JENKINS-19830](https://issues.jenkins-ci.org/browse/JENKINS-19830)

Alternate fix is to replace

```
args.add(parameters.toString());
```

with

```
args.addMasked(parameters.toString());
```

but this could impair debugging. Could make it an option.
