### PR TITLE
Fix grammar and spelling in help-continueOnBuildFailure.html

### DIFF
--- a/src/main/resources/hudson/plugins/msbuild/MsBuildBuilder/help-continueOnBuildFailure.html
+++ b/src/main/resources/hudson/plugins/msbuild/MsBuildBuilder/help-continueOnBuildFailure.html
@@ -1,5 +1,5 @@
 <div>
     <p>
-        If set to true, Job will continue dispite of MSBuild build failure.
+        If set to true, Job will continue despite MSBuild build failure.
     </p>
 </div>


### PR DESCRIPTION
dispite not a word. Despite should not be followed by 'of'.