### PR TITLE
[FIXED JENKINS-9104] Veto killing mspdbsrv.exe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.565.1</version>
+        <version>1.625</version>
     </parent>
 
     <artifactId>msbuild</artifactId>

--- a/src/main/java/hudson/plugins/msbuild/MsBuildKillingVeto.java
+++ b/src/main/java/hudson/plugins/msbuild/MsBuildKillingVeto.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014, Kyle Sweeney, Gregory Boissinot and other contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.msbuild;
+
+import hudson.Extension;
+import hudson.util.ProcessKillingVeto;
+import hudson.util.ProcessTreeRemoting.IOSProcess;
+
+import java.util.List;
+
+import org.apache.commons.io.FilenameUtils;
+
+/**
+ * An extension that avoids mspdbsrv.exe being killed by Jenkins.
+ * 
+ * Requires a Jenkins version >= 1.619. Will simply be ignored for older versions.
+ * 
+ * @see JENKINS-9104
+ * 
+ * @author Daniel Weber <daniel.weber.dev@gmail.com>
+ */
+@Extension(optional = true)
+public class MsBuildKillingVeto extends ProcessKillingVeto {
+    private static final VetoCause VETO_CAUSE = new VetoCause("MSBuild Plugin vetoes killing mspdbsrv.exe, see JENKINS-9104 for all the details");
+
+    /**
+    * 
+    */
+    @Override
+    public VetoCause vetoProcessKilling(IOSProcess proc) {
+        if (proc == null)
+            return null;
+
+        List<String> cmdLine = proc.getArguments();
+        if (cmdLine == null || cmdLine.isEmpty())
+            return null;
+
+        String command = cmdLine.get(0);
+        String exeName = FilenameUtils.getName(command);
+        if (exeName.toLowerCase().equals("mspdbsrv.exe")) {
+            return VETO_CAUSE;
+        }
+        return null;
+    }
+}

--- a/src/test/java/hudson/plugins/msbuild/MsBuildKillingVetoTest.java
+++ b/src/test/java/hudson/plugins/msbuild/MsBuildKillingVetoTest.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014, Kyle Sweeney, Gregory Boissinot and other contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.msbuild;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import hudson.EnvVars;
+import hudson.util.ProcessKillingVeto.VetoCause;
+import hudson.util.ProcessTree.ProcessCallable;
+import hudson.util.ProcessTreeRemoting.IOSProcess;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+public class MsBuildKillingVetoTest {
+
+    private MsBuildKillingVeto testee;
+
+    @Before
+    public void setUp() {
+        testee = new MsBuildKillingVeto();
+    }
+
+    @Test
+    public void testSparesMsPDBSrv() {
+        VetoCause veto = testee.vetoProcessKilling(mockProcess("C:\\Program Files (x86)\\Microsoft Visual Studio\\bin\\mspdbsrv.exe", "something", "else"));
+        assertNotNull(veto);
+        assertEquals("MSBuild Plugin vetoes killing mspdbsrv.exe, see JENKINS-9104 for all the details", veto.getMessage());
+    }
+
+    @Test
+    public void testIgnoresCase() {
+        VetoCause veto = testee.vetoProcessKilling(mockProcess("C:\\Program Files (x86)\\Microsoft Visual Studio\\bin\\MsPdbSrv.exe", "something", "else"));
+        assertNotNull(veto);
+        assertEquals("MSBuild Plugin vetoes killing mspdbsrv.exe, see JENKINS-9104 for all the details", veto.getMessage());
+    }
+
+    @Test
+    public void testPathDoesNotMatter() {
+        VetoCause veto = testee.vetoProcessKilling(mockProcess("D:/Tools/mspdbsrv.exe"));
+        assertNotNull(veto);
+        assertEquals("MSBuild Plugin vetoes killing mspdbsrv.exe, see JENKINS-9104 for all the details", veto.getMessage());
+    }
+
+    @Test
+    public void testLeavesOthersAlone() {
+        assertNull(testee.vetoProcessKilling(mockProcess("D:/Tools/somethingElse.exe")));
+        assertNull(testee.vetoProcessKilling(mockProcess("C:\\Program Files (x86)\\Microsoft Visual Studio\\bin\\cl.exe")));
+        assertNull(testee.vetoProcessKilling(mockProcess("C:\\Program Files (x86)\\Microsoft Visual Studio\\bin\\link.exe")));
+    }
+
+    private IOSProcess mockProcess(final String... cmdLine) {
+        return new IOSProcess() {
+            public void killRecursively() throws InterruptedException {
+            }
+
+            @Override
+            public void kill() throws InterruptedException {
+            }
+
+            @Override
+            public int getPid() {
+                return 0;
+            }
+
+            @Override
+            public IOSProcess getParent() {
+                return null;
+            }
+
+            @Override
+            public EnvVars getEnvironmentVariables() {
+                return null;
+            }
+
+            @Override
+            public List<String> getArguments() {
+                return Lists.newArrayList(cmdLine);
+            }
+
+            @Override
+            public <T> T act(ProcessCallable<T> arg0) throws IOException, InterruptedException {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Making use of the newly introduced ProcessKillingVeto extension point,
we now make sure that mspdbsrv.exe survives process killing during build
cleanup.

This requires a Jenkins version >= 1.619, the new extension point was
added there. I marked the extension as optional, so that the msbuild
plugin should still work with older Jenkins releases.