### PR TITLE
[JENKINS-33321] Upgrade to new parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.625</version>
+        <version>2.3</version>
     </parent>
 
     <artifactId>msbuild</artifactId>
@@ -19,6 +19,11 @@
             <comments>All source code is under the MIT license.</comments>
         </license>
     </licenses>
+    
+    <properties>
+      <jenkins.version>1.625</jenkins.version>
+      <java.level>6</java.level>
+    </properties>
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.3</version>
+        <version>2.6</version>
     </parent>
 
     <artifactId>msbuild</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
     
     <properties>
       <jenkins.version>1.625</jenkins.version>
-      <java.level>6</java.level>
     </properties>
 
     <developers>

--- a/src/main/java/hudson/plugins/msbuild/MsBuildInstallation.java
+++ b/src/main/java/hudson/plugins/msbuild/MsBuildInstallation.java
@@ -71,12 +71,22 @@ public final class MsBuildInstallation extends ToolInstallation implements NodeS
 
         @Override
         public MsBuildInstallation[] getInstallations() {
-            return Jenkins.getInstance().getDescriptorByType(MsBuildBuilder.DescriptorImpl.class).getInstallations();
+            return getDescriptor().getInstallations();
         }
 
         @Override
         public void setInstallations(MsBuildInstallation... installations) {
-            Jenkins.getInstance().getDescriptorByType(MsBuildBuilder.DescriptorImpl.class).setInstallations(installations);
+            getDescriptor().setInstallations(installations);
+        }
+        
+        private MsBuildBuilder.DescriptorImpl getDescriptor() {
+            Jenkins jenkins = Jenkins.getInstance();
+            if (jenkins != null && jenkins.getDescriptorByType(MsBuildBuilder.DescriptorImpl.class) != null) {
+                return jenkins.getDescriptorByType(MsBuildBuilder.DescriptorImpl.class);
+            } else {
+                // To stick with current behavior and meet findbugs requirements
+                throw new NullPointerException(jenkins == null ? "Jenkins instance is null" : "MsBuildBuilder.DescriptorImpl is null");
+            }
         }
 
     }

--- a/src/main/java/hudson/plugins/msbuild/MsBuildKillingVeto.java
+++ b/src/main/java/hudson/plugins/msbuild/MsBuildKillingVeto.java
@@ -34,11 +34,11 @@ import org.apache.commons.io.FilenameUtils;
 /**
  * An extension that avoids mspdbsrv.exe being killed by Jenkins.
  * 
- * Requires a Jenkins version >= 1.619. Will simply be ignored for older versions.
+ * Requires a Jenkins version &gt;= 1.619. Will simply be ignored for older versions.
  * 
- * @see JENKINS-9104
+ * See JENKINS-9104
  * 
- * @author Daniel Weber <daniel.weber.dev@gmail.com>
+ * @author Daniel Weber &lt;daniel.weber.dev@gmail.com&gt;
  */
 @Extension(optional = true)
 public class MsBuildKillingVeto extends ProcessKillingVeto {

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
     This plugin makes it possible to build a Visual Studio project (.proj) and solution files (.sln).
 </div>


### PR DESCRIPTION
Upgrade to new parent pom. Includes many improvements. More info [here](https://github.com/jenkinsci/plugin-pom)

- [x] Upgrade to new parent pom (version 2.3) keeping the same baseline version (1.625).
- [x] Fix Injected test due to upgrade.
- [x] Fix Findbugs issues.
- [x] Fix Javadoc so that maven javadoc plugin doesn't complain.

@reviewbybees 