### PR TITLE
Fixes warning in system admin section + color highlighting of warning and errors 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,11 @@
             <name>Kyle Sweeney</name>
             <email>kyle.sweeney@valtech.com</email>
         </developer>
+        <developer>
+            <id>marshall777</id>
+            <name>Lionel Cabasson</name>
+            <email>marshall777@gmail.com</email>
+        </developer>
     </developers>
 
     <scm>

--- a/src/main/java/hudson/plugins/msbuild/MSBuildConsoleAnnotator.java
+++ b/src/main/java/hudson/plugins/msbuild/MSBuildConsoleAnnotator.java
@@ -1,0 +1,59 @@
+package hudson.plugins.msbuild;
+
+import hudson.console.LineTransformationOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.regex.Matcher;
+
+public class MSBuildConsoleAnnotator extends LineTransformationOutputStream {
+    private final OutputStream out;
+    private final Charset charset;
+    
+    private int numberOfWarnings = 0;
+    private int numberOfErrors = 0;
+    
+    public MSBuildConsoleAnnotator(OutputStream out, Charset charset) {
+        this.out = out;
+        this.charset = charset;
+    }
+    
+    public int getNumberOfWarnings() {
+        return numberOfWarnings;
+    }
+    
+    public int getNumberOfErrors() {
+        return numberOfErrors;
+    }
+    
+    @Override
+    protected void eol(byte[] b, int len) throws IOException {
+        String line = charset.decode(ByteBuffer.wrap(b, 0, len)).toString();
+        
+        // trim off CR/LF from the end
+        line = trimEOL(line);
+        
+        // Error messages handler
+        Matcher m = MSBuildErrorNote.PATTERN.matcher(line);
+        if (m.matches()) { // Match the number of warnings
+            new MSBuildErrorNote().encodeTo(out);
+            this.numberOfErrors++;
+        }
+        
+        // Warning messages handler
+        m = MSBuildWarningNote.PATTERN.matcher(line);
+        if (m.matches()) { // Match the number of warnings
+            new MSBuildWarningNote().encodeTo(out);
+            this.numberOfWarnings++;
+        }
+        
+        out.write(b, 0, len);
+    }
+    
+    @Override
+    public void close() throws IOException {
+        super.close();
+        out.close();
+    }
+}

--- a/src/main/java/hudson/plugins/msbuild/MSBuildErrorNote.java
+++ b/src/main/java/hudson/plugins/msbuild/MSBuildErrorNote.java
@@ -1,0 +1,33 @@
+package hudson.plugins.msbuild;
+
+import hudson.Extension;
+import hudson.MarkupText;
+import hudson.console.ConsoleAnnotationDescriptor;
+import hudson.console.ConsoleAnnotator;
+import hudson.console.ConsoleNote;
+import java.util.regex.Pattern;
+
+/**
+ * Annotation for MSBuild and CSC error messages
+ */
+public class MSBuildErrorNote extends ConsoleNote {
+    /** Pattern to identify doxygen error message */
+    public static Pattern PATTERN = Pattern.compile("(.*)[Ee]rror\\s(CS|MSB)\\d+(.*)");
+    
+    public MSBuildErrorNote() {
+    }
+
+    @Override
+    public ConsoleAnnotator annotate(Object context, MarkupText text, int charPos) {
+        text.addMarkup(0, text.length(), "<span class=error-inline>", "</span>");
+        return null;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+
+        public String getDisplayName() {
+            return Messages.MsBuildBuilder_ErrorNoteDescription();
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/msbuild/MSBuildErrorNote.java
+++ b/src/main/java/hudson/plugins/msbuild/MSBuildErrorNote.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
  */
 public class MSBuildErrorNote extends ConsoleNote {
     /** Pattern to identify doxygen error message */
-    public static Pattern PATTERN = Pattern.compile("(.*)[Ee]rror\\s(CS|MSB)\\d+(.*)");
+    public final static Pattern PATTERN = Pattern.compile("(.*)[Ee]rror\\s(CS|MSB)\\d+(.*)");
     
     public MSBuildErrorNote() {
     }

--- a/src/main/java/hudson/plugins/msbuild/MSBuildWarningNote.java
+++ b/src/main/java/hudson/plugins/msbuild/MSBuildWarningNote.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
  */
 public class MSBuildWarningNote extends ConsoleNote {
     /** Pattern to identify doxygen warning message */
-    public static Pattern PATTERN = Pattern.compile("(.*)\\(\\d+,\\d+\\):\\swarning\\s:\\s(.*)");
+    public final static Pattern PATTERN = Pattern.compile("(.*)\\(\\d+,\\d+\\):\\swarning\\s((MSB|CS)\\d+){0,1}:\\s(.*)");
     
     public MSBuildWarningNote() {
     }

--- a/src/main/java/hudson/plugins/msbuild/MSBuildWarningNote.java
+++ b/src/main/java/hudson/plugins/msbuild/MSBuildWarningNote.java
@@ -1,0 +1,33 @@
+package hudson.plugins.msbuild;
+
+import hudson.Extension;
+import hudson.MarkupText;
+import hudson.console.ConsoleAnnotationDescriptor;
+import hudson.console.ConsoleAnnotator;
+import hudson.console.ConsoleNote;
+import java.util.regex.Pattern;
+
+/**
+ * Annotation for MSBuild warning messages
+ */
+public class MSBuildWarningNote extends ConsoleNote {
+    /** Pattern to identify doxygen warning message */
+    public static Pattern PATTERN = Pattern.compile("(.*)\\(\\d+,\\d+\\):\\swarning\\s:\\s(.*)");
+    
+    public MSBuildWarningNote() {
+    }
+
+    @Override
+    public ConsoleAnnotator annotate(Object context, MarkupText text, int charPos) {
+        text.addMarkup(0, text.length(), "<span class=warning-inline>", "</span>");
+        return null;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+
+        public String getDisplayName() {
+            return Messages.MsBuildBuilder_WarningNoteDescription();
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/msbuild/MsBuildBuilder.java
+++ b/src/main/java/hudson/plugins/msbuild/MsBuildBuilder.java
@@ -199,8 +199,9 @@ public class MsBuildBuilder extends Builder {
             listener.getLogger().println(String.format("Executing the command %s from %s", args.toStringWithQuote(), pwd));
             // Parser to find the number of Warnings/Errors
             MsBuildConsoleParser mbcp = new MsBuildConsoleParser(listener.getLogger(), build.getCharset());
+            MSBuildConsoleAnnotator annotator = new MSBuildConsoleAnnotator(listener.getLogger(), build.getCharset());
             // Launch the msbuild.exe
-            int r = launcher.launch().cmds(args).envs(env).stdout(mbcp).pwd(pwd).join();
+            int r = launcher.launch().cmds(args).envs(env).stdout(mbcp).stdout(annotator).pwd(pwd).join();
             // Check the number of warnings
             if (unstableIfWarnings && mbcp.getNumberOfWarnings() > 0) {
                 listener.getLogger().println("> Set build UNSTABLE because there are warnings.");

--- a/src/main/java/hudson/plugins/msbuild/MsBuildBuilder.java
+++ b/src/main/java/hudson/plugins/msbuild/MsBuildBuilder.java
@@ -128,7 +128,7 @@ public class MsBuildBuilder extends Builder {
             if (node != null) {
                 ai = ai.forNode(node, listener);
                 ai = ai.forEnvironment(env);
-                String pathToMsBuild = ai.getHome();
+                String pathToMsBuild = getToolFullPath(launcher, ai.getHome(), execName);
                 FilePath exec = new FilePath(launcher.getChannel(), pathToMsBuild);
     
                 try {
@@ -232,6 +232,27 @@ public class MsBuildBuilder extends Builder {
         return buildVariables;
     }
 
+    /**
+     * Get the full path of the tool to run.
+     * If given path is a directory, this will append the executable name.
+     */
+    static String getToolFullPath(Launcher launcher, String pathToTool, String execName) throws IOException, InterruptedException
+    {
+        String fullPathToMsBuild = pathToTool;
+        
+        FilePath exec = new FilePath(launcher.getChannel(), fullPathToMsBuild);
+        if (exec.isDirectory())
+        {
+            if (!fullPathToMsBuild.endsWith("\\"))
+            {
+                fullPathToMsBuild = fullPathToMsBuild + "\\";
+            }
+
+            fullPathToMsBuild = fullPathToMsBuild + execName;
+        }
+        
+        return fullPathToMsBuild;
+    }
 
     @Override
     public Descriptor<Builder> getDescriptor() {

--- a/src/main/resources/hudson/plugins/msbuild/Messages.properties
+++ b/src/main/resources/hudson/plugins/msbuild/Messages.properties
@@ -21,3 +21,5 @@
 # THE SOFTWARE.
 
 MsBuildBuilder.DisplayName=Build a Visual Studio project or solution using MSBuild
+MsBuildBuilder.ErrorNoteDescription=MSBuild error
+MsBuildBuilder.WarningNoteDescription=MSBuild warning

--- a/src/main/resources/hudson/plugins/msbuild/Messages_fr.properties
+++ b/src/main/resources/hudson/plugins/msbuild/Messages_fr.properties
@@ -21,3 +21,5 @@
 # THE SOFTWARE.
 
 MsBuildBuilder.DisplayName=Construire un projet Visual Studio avec MSBuild
+MsBuildBuilder.ErrorNoteDescription=Erreur MSBuild
+MsBuildBuilder.WarningNoteDescription=Avertissement MSBuild


### PR DESCRIPTION
Hello,

This pull request fixes the warning message displayed in administration when setting the "path to msbuild" to the directory containing msbuild.exe. Previously, you had to fill this field with the full path to msbuild.exe while Jenkins expects it to be the directory containing the executable.
This PR makes the plugin work when only the directory is set and also keep working if the full path to msbuild.exe is set for backward compatibility purpose.

Moreover, it also add color to the console log for warning and error messages generated by msbuild.