### PR TITLE
Broadened warning and error selection

### DIFF
--- a/src/main/java/hudson/plugins/msbuild/MSBuildErrorNote.java
+++ b/src/main/java/hudson/plugins/msbuild/MSBuildErrorNote.java
@@ -11,8 +11,8 @@ import java.util.regex.Pattern;
  * Annotation for MSBuild and CSC error messages
  */
 public class MSBuildErrorNote extends ConsoleNote {
-    /** Pattern to identify doxygen error message */
-    public final static Pattern PATTERN = Pattern.compile("(.*)[Ee]rror\\s(CS|MSB)\\d+(.*)");
+    /** Pattern to identify error messages */
+    public final static Pattern PATTERN = Pattern.compile("(.*)[Ee]rror\\s(([A-Z]*)\\d+){0,1}:\\s(.*)");
     
     public MSBuildErrorNote() {
     }

--- a/src/main/java/hudson/plugins/msbuild/MSBuildWarningNote.java
+++ b/src/main/java/hudson/plugins/msbuild/MSBuildWarningNote.java
@@ -11,8 +11,8 @@ import java.util.regex.Pattern;
  * Annotation for MSBuild warning messages
  */
 public class MSBuildWarningNote extends ConsoleNote {
-    /** Pattern to identify doxygen warning message */
-    public final static Pattern PATTERN = Pattern.compile("(.*)\\(\\d+,\\d+\\):\\swarning\\s((MSB|CS)\\d+){0,1}:\\s(.*)");
+    /** Pattern to identify warning messages */
+    public final static Pattern PATTERN = Pattern.compile("(.*)\\(\\d+(,\\d+){0,1}\\):\\s[Ww]arning\\s(([A-Z]*)\\d+){0,1}:\\s(.*)");
     
     public MSBuildWarningNote() {
     }


### PR DESCRIPTION
Adding the changes with this pull request should select more messages from the MSBuild output as warnings and errors for some important languages and build tools. E.g. identifying the C++ compiler and linker warnings as well as such messages from the WiX toolset. 