### PR TITLE
[JENKINS-42284] Fix for chcp errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.20</version>
+        <version>2.36</version>
     </parent>
 
     <artifactId>msbuild</artifactId>

--- a/src/main/java/hudson/plugins/msbuild/MsBuildBuilder.java
+++ b/src/main/java/hudson/plugins/msbuild/MsBuildBuilder.java
@@ -259,7 +259,7 @@ public class MsBuildBuilder extends Builder {
      */
     static String getToolFullPath(Launcher launcher, String pathToTool, String execName) throws IOException, InterruptedException
     {
-        String fullPathToMsBuild = pathToTool;
+        String fullPathToMsBuild = (pathToTool != null ? pathToTool : "");
         
         FilePath exec = new FilePath(launcher.getChannel(), fullPathToMsBuild);
         if (exec.isDirectory())

--- a/src/main/java/hudson/plugins/msbuild/MsBuildBuilder.java
+++ b/src/main/java/hudson/plugins/msbuild/MsBuildBuilder.java
@@ -204,7 +204,7 @@ public class MsBuildBuilder extends Builder {
             if (!doNotUseChcpCommand) {
                 final int cpi = getCodePageIdentifier(build.getCharset());
                 if(cpi != 0) {
-                    args.prepend("chcp", String.valueOf(cpi), "&&");
+                    args.prepend("chcp", String.valueOf(cpi), "&");
                 }
             }
             

--- a/src/main/java/hudson/plugins/msbuild/MsBuildInstallation.java
+++ b/src/main/java/hudson/plugins/msbuild/MsBuildInstallation.java
@@ -85,11 +85,11 @@ public final class MsBuildInstallation extends ToolInstallation implements NodeS
         
         private MsBuildBuilder.DescriptorImpl getDescriptor() {
             Jenkins jenkins = Jenkins.getInstance();
-            if (jenkins != null && jenkins.getDescriptorByType(MsBuildBuilder.DescriptorImpl.class) != null) {
+            if (jenkins.getDescriptorByType(MsBuildBuilder.DescriptorImpl.class) != null) {
                 return jenkins.getDescriptorByType(MsBuildBuilder.DescriptorImpl.class);
             } else {
                 // To stick with current behavior and meet findbugs requirements
-                throw new NullPointerException(jenkins == null ? "Jenkins instance is null" : "MsBuildBuilder.DescriptorImpl is null");
+                throw new NullPointerException("MsBuildBuilder.DescriptorImpl is null");
             }
         }
 

--- a/src/main/resources/hudson/plugins/msbuild/MsBuildBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/msbuild/MsBuildBuilder/config.jelly
@@ -41,6 +41,10 @@ THE SOFTWARE.
         <f:checkbox name="msBuildBuilder.buildVariablesAsProperties" value="${instance.buildVariablesAsProperties}"
                     checked="${instance.buildVariablesAsProperties}" default="false"/>
     </f:entry>
+    <f:entry title="${%Do not use chcp command}" field="doNotUseChcpCommand">
+        <f:checkbox name="msBuildBuilder.doNotUseChcpCommand" value="${instance.doNotUseChcpCommand}"
+                    checked="${instance.doNotUseChcpCommand}" default="false"/>
+    </f:entry>
     <f:advanced>
         <f:entry title="${%Continue Job on build Failure}" field="continueOnBuildFailure">
             <f:checkbox name="msBuildBuilder.continueOnBuildFailure" value="${instance.continueOnBuildFailure}"


### PR DESCRIPTION
These modifications include :
- The ability to prevent the chcp command from being run using a checkbox available on build step
- The chcp command no more fail the whole build in case of error. The error is simply ignored and msbuild is run so that the build continues.

By the way, the parent POM version has been upgraded.