### PR TITLE
WIP Java 11 readiness: build both on JDK8 and JDK11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(platforms: ['windows'])
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.36</version>
+        <version>3.42</version>
     </parent>
 
     <artifactId>msbuild</artifactId>
@@ -23,6 +23,7 @@
     
     <properties>
       <jenkins.version>1.625</jenkins.version>
+      <java.level>8</java.level>
     </properties>
 
     <developers>


### PR DESCRIPTION
Making sure this plugin is constantly checked both building with JDK8 and JDK11.

This goes with the Jenkins Java 11 General Availability announcement made back in March, and we're making a pass to check plugins are looking good on a JDK11.

([to understand the Jenkinsfile content](https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime))


@jenkinsci/java11-support 