### PR TITLE
Require Jenkins 2.332.4 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
     </licenses>
     
     <properties>
-        <jenkins.version>2.222</jenkins.version>
-        <revision>1.30</revision>
+        <jenkins.version>2.332.4</jenkins.version>
+        <revision>2.222</revision>
         <changelist>-SNAPSHOT</changelist>
     </properties>
 
@@ -58,8 +58,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.222.x</artifactId>
-                <version>24</version>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1706.vc166d5f429f8</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     
     <properties>
         <jenkins.version>2.332.4</jenkins.version>
-        <revision>1.38</revision>
+        <revision>1.30</revision>
         <changelist>-SNAPSHOT</changelist>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     
     <properties>
         <jenkins.version>2.332.4</jenkins.version>
-        <revision>2.222</revision>
+        <revision>1.38</revision>
         <changelist>-SNAPSHOT</changelist>
     </properties>
 


### PR DESCRIPTION
Require Jenkins 2.332.4 or newer so that users are motivated to update to newer versions and plugin maintainers are not miscommunicating the range of versions they are willing to support.

Followed this tutorial: https://www.jenkins.io/doc/developer/tutorial-improve/use-plugin-bill-of-materials/

Updated to latest `bom`  version. Then ran `mvn clean verify` to make sure nothing fails. 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

