### PR TITLE
Require Jenkins 2.426.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </scm>
 
     <properties>
-        <jenkins.version>2.401.1</jenkins.version>
+        <jenkins.version>2.426.3</jenkins.version>
         <revision>1.34</revision>
         <changelist>-SNAPSHOT</changelist>
         <spotbugs.effort>Max</spotbugs.effort>
@@ -42,8 +42,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.401.x</artifactId>
-                <version>2745.vc7b_fe4c876fa_</version>
+                <artifactId>bom-2.426.x</artifactId>
+                <version>3208.vb_21177d4b_cd9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Require Jenkins 2.426.3 or newer

Users that are upgrading the plugin are already running 2.426.3 or newer.  Jenkins 2.426.3 includes a critical security fix that should be used by all Jenkins users.  It is a good choice for minimum Jenkins version.

https://stats.jenkins.io/pluginversions/msbuild.html shows that:

* 92% of 1.31 installations are already running Jenkins 2.426.3 or newer
* 95% of 1.32 installations are already running Jenkins 2.426.3 or newer
* 97% of 1.33 installations are already running Jenkins 2.426.3 or newer

### Testing done

Confirmed that `mvn clean verify` passes on my Linux computer.  Rely on ci.jenkins.io to check the Windows configurations.  No surprises expected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
