### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.7</version>
         <relativePath />
     </parent>
 
@@ -31,8 +31,8 @@
     </scm>
 
     <properties>
-        <jenkins.baseline>2.426</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <revision>1.34</revision>
         <changelist>-SNAPSHOT</changelist>
         <spotbugs.effort>Max</spotbugs.effort>
@@ -44,7 +44,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3208.vb_21177d4b_cd9</version>
+                <version>4051.v78dce3ce8b_d6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/hudson/plugins/msbuild/MSBuildErrorNote.java
+++ b/src/main/java/hudson/plugins/msbuild/MSBuildErrorNote.java
@@ -7,6 +7,7 @@ import hudson.console.ConsoleAnnotator;
 import hudson.console.ConsoleNote;
 import org.jenkinsci.Symbol;
 
+import java.io.Serial;
 import java.util.regex.Pattern;
 
 /**
@@ -15,6 +16,7 @@ import java.util.regex.Pattern;
 public class MSBuildErrorNote extends ConsoleNote<Object> {
     /** Pattern to identify error messages */
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public final static Pattern PATTERN = Pattern.compile("(.*)[Ee]rror\\s(([A-Z]*)\\d+){0,1}:\\s(.*)");

--- a/src/main/java/hudson/plugins/msbuild/MSBuildWarningNote.java
+++ b/src/main/java/hudson/plugins/msbuild/MSBuildWarningNote.java
@@ -4,6 +4,8 @@ import hudson.MarkupText;
 import hudson.console.ConsoleAnnotationDescriptor;
 import hudson.console.ConsoleAnnotator;
 import hudson.console.ConsoleNote;
+
+import java.io.Serial;
 import java.util.regex.Pattern;
 
 /**
@@ -12,10 +14,11 @@ import java.util.regex.Pattern;
 public class MSBuildWarningNote extends ConsoleNote<Object> {
     /** Pattern to identify warning messages */
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public final static Pattern PATTERN = Pattern.compile("(.*)\\(\\d+(,\\d+){0,1}\\):\\s[Ww]arning\\s(([A-Z]*)\\d+){0,1}:\\s(.*)");
-    
+
     public MSBuildWarningNote() {
     }
 

--- a/src/main/java/hudson/plugins/msbuild/MsBuildBuilder.java
+++ b/src/main/java/hudson/plugins/msbuild/MsBuildBuilder.java
@@ -103,7 +103,7 @@ public class MsBuildBuilder extends Builder {
         CHARSET_CODE_MAP.put("IBM280", 20280);
         CHARSET_CODE_MAP.put("IBM284", 20284);
         CHARSET_CODE_MAP.put("IBM285", 20285);
-        CHARSET_CODE_MAP.put("IBM297", 20297);  
+        CHARSET_CODE_MAP.put("IBM297", 20297);
         CHARSET_CODE_MAP.put("IBM420", 20420);
         CHARSET_CODE_MAP.put("IBM424", 20424);
         CHARSET_CODE_MAP.put("IBM500", 500);
@@ -272,13 +272,13 @@ public class MsBuildBuilder extends Builder {
         normalizedArgs = Util.replaceMacro(normalizedArgs, env);
         normalizedArgs = Util.replaceMacro(normalizedArgs, build.getBuildVariables());
 
-        if (normalizedArgs.trim().length() > 0)
+        if (!normalizedArgs.trim().isEmpty())
             args.add(tokenizeArgs(normalizedArgs));
 
         // Build /P:key1=value1;key2=value2 ...
         Map<String, String> propertiesVariables = getPropertiesVariables(build);
         if (buildVariablesAsProperties && !propertiesVariables.isEmpty()) {
-            StringBuffer parameters = new StringBuffer();
+            StringBuilder parameters = new StringBuilder();
             parameters.append("/p:");
             for (Map.Entry<String, String> entry : propertiesVariables.entrySet()) {
                 parameters.append(entry.getKey()).append("=").append(entry.getValue()).append(";");
@@ -290,7 +290,7 @@ public class MsBuildBuilder extends Builder {
         // If a msbuild file is specified, then add it as an argument, otherwise
         // msbuild will search for any file that ends in .proj or .sln
         String normalizedFile = null;
-        if (msBuildFile != null && msBuildFile.trim().length() != 0) {
+        if (msBuildFile != null && !msBuildFile.trim().isEmpty()) {
             normalizedFile = msBuildFile.replaceAll("[\t\r\n]+", " ");
             normalizedFile = Util.replaceMacro(normalizedFile, env);
             normalizedFile = Util.replaceMacro(normalizedFile, build.getBuildVariables());
@@ -323,7 +323,7 @@ public class MsBuildBuilder extends Builder {
 
         try {
             listener.getLogger()
-                    .println(String.format("Executing the command %s from %s", args.toStringWithQuote(), pwd));
+                    .printf("Executing the command %s from %s%n", args.toStringWithQuote(), pwd);
             // Parser to find the number of Warnings/Errors
             MsBuildConsoleParser mbcp = new MsBuildConsoleParser(listener.getLogger(), build.getCharset());
             MSBuildConsoleAnnotator annotator = new MSBuildConsoleAnnotator(listener.getLogger(), build.getCharset());
@@ -335,7 +335,7 @@ public class MsBuildBuilder extends Builder {
                 build.setResult(Result.UNSTABLE);
             }
             // Return the result of the compilation
-            return continueOnBuildFailure ? true : (r == 0);
+            return continueOnBuildFailure || (r == 0);
         } catch (IOException e) {
             Util.displayIOException(e, listener);
             build.setResult(Result.FAILURE);
@@ -425,7 +425,6 @@ public class MsBuildBuilder extends Builder {
         }
 
         @Override
-        @SuppressWarnings("rawtypes")
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
             return true;
         }

--- a/src/main/java/hudson/plugins/msbuild/MsBuildInstallation.java
+++ b/src/main/java/hudson/plugins/msbuild/MsBuildInstallation.java
@@ -38,8 +38,9 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.Symbol;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
+import java.io.Serial;
 import java.util.Collections;
 import java.util.List;
 import java.io.IOException;
@@ -50,6 +51,7 @@ import java.io.IOException;
 public final class MsBuildInstallation extends ToolInstallation
         implements NodeSpecific<MsBuildInstallation>, EnvironmentSpecific<MsBuildInstallation> {
 
+    @Serial
     private static final long serialVersionUID = 1L;
     private final String defaultArgs;
 
@@ -111,7 +113,7 @@ public final class MsBuildInstallation extends ToolInstallation
         }
 
         @Override
-        public MsBuildInstallation newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public MsBuildInstallation newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             return (MsBuildInstallation)super.newInstance(req, formData);
         }
     }

--- a/src/main/java/hudson/plugins/msbuild/MsBuildKillingVeto.java
+++ b/src/main/java/hudson/plugins/msbuild/MsBuildKillingVeto.java
@@ -35,12 +35,12 @@ import org.jenkinsci.Symbol;
 
 /**
  * An extension that avoids mspdbsrv.exe being killed by Jenkins.
- * 
+ * <p>
  * Requires a Jenkins version &gt;= 1.619. Will simply be ignored for older
  * versions.
- * 
+ * <p>
  * See JENKINS-9104
- * 
+ *
  * @author Daniel Weber &lt;daniel.weber.dev@gmail.com&gt;
  */
 @Extension(optional = true)
@@ -50,7 +50,7 @@ public class MsBuildKillingVeto extends ProcessKillingVeto {
             "MSBuild Plugin vetoes killing mspdbsrv.exe, see JENKINS-9104 for all the details");
 
     /**
-    * 
+    *
     */
     @Override
     public VetoCause vetoProcessKilling(IOSProcess proc) {

--- a/src/test/java/hudson/plugins/msbuild/MsBuildBuilderTest.java
+++ b/src/test/java/hudson/plugins/msbuild/MsBuildBuilderTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author Jonathan Zimmerman
@@ -63,7 +64,7 @@ public class MsBuildBuilderTest {
     @Test
     public void testValidCharset() {
         // Assuming CHARSET_CODE_MAP is populated with UTF-8 -> 65001
-        Charset charset = Charset.forName("UTF-8");
+        Charset charset = StandardCharsets.UTF_8;
         int expectedCodePage = 65001;
         int actualCodePage = MsBuildBuilder.getCodePageIdentifier(charset);
         assertEquals("Code page should match expected for UTF-8", expectedCodePage, actualCodePage);
@@ -87,7 +88,7 @@ public class MsBuildBuilderTest {
     @Test
     public void testCaseSensitivity() {
         // Verify case insensitivity by testing an all-lowercase input
-        Charset charset = Charset.forName("utf-8");
+        Charset charset = StandardCharsets.UTF_8;
         int expectedCodePage = 65001;
         int actualCodePage = MsBuildBuilder.getCodePageIdentifier(charset);
         assertEquals("Code page should match expected regardless of case", expectedCodePage, actualCodePage);

--- a/src/test/java/hudson/plugins/msbuild/MsBuildInstallerTest.java
+++ b/src/test/java/hudson/plugins/msbuild/MsBuildInstallerTest.java
@@ -6,7 +6,6 @@ import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
-import hudson.util.ListBoxModel;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -185,7 +184,7 @@ public class MsBuildInstallerTest {
         verifyNoMoreInteractions(vsConfigFilePath);
         assertFalse(result);
     }
-    
+
     @Test
     public void testUseConfigFileWithEmptyVsConfig() throws IOException, InterruptedException {
         boolean result = MsBuildInstaller.useConfigFile("", mockFilePath);


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Jenkins 2.479.1 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features

### Testing done

Confirmed that tests pass.

### Submitter checklist
* [x]  Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x]  Ensure that the pull request title represents the desired changelog entry
* [x]  Please describe what you did
* [x]  Link to relevant issues in GitHub or Jira
* [x]  Link to relevant pull requests, esp. upstream and downstream changes
* [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue
